### PR TITLE
Rename Symbol → LSymbol, harden LString immutability

### DIFF
--- a/src/Physis.jl
+++ b/src/Physis.jl
@@ -4,7 +4,7 @@ module Physis
 include("core/symbols.jl")
 
 # Re-export public API
-export AbstractSymbol, Symbol, ParametricSymbol, LString
+export AbstractSymbol, LSymbol, ParametricSymbol, LString
 export name, arity, params, matches
 
 end # module Physis

--- a/src/core/symbols.jl
+++ b/src/core/symbols.jl
@@ -1,5 +1,5 @@
 """
-    symbols.jl — L-system alphabet: Symbol, ParametricSymbol, LString
+    symbols.jl — L-system alphabet: LSymbol, ParametricSymbol, LString
 
 Symbol types represent the alphabet of an L-system. Plain symbols carry only
 a character; parametric symbols additionally carry a tuple of Float64 parameters.
@@ -25,24 +25,24 @@ abstract type AbstractSymbol end
 # ──────────────────────────────────────────────────────────────────
 
 """
-    Symbol(char)
+    LSymbol(char)
 
 A plain (non-parametric) L-system symbol identified by a single `Char`.
 """
-struct Symbol <: AbstractSymbol
+struct LSymbol <: AbstractSymbol
     char::Char
 end
 
-Base.:(==)(a::Symbol, b::Symbol) = a.char == b.char
-Base.hash(s::Symbol, h::UInt) = hash(s.char, hash(:Symbol, h))
-Base.show(io::IO, s::Symbol) = print(io, s.char)
+Base.:(==)(a::LSymbol, b::LSymbol) = a.char == b.char
+Base.hash(s::LSymbol, h::UInt) = hash(s.char, hash(:LSymbol, h))
+Base.show(io::IO, s::LSymbol) = print(io, s.char)
 
 """
-    name(s::Symbol)
+    name(s::LSymbol)
 
 Return the character identifier of a plain symbol.
 """
-name(s::Symbol) = s.char
+name(s::LSymbol) = s.char
 
 # ──────────────────────────────────────────────────────────────────
 # Parametric symbol  (e.g. F(1.0), A(10, 3.5))
@@ -78,6 +78,7 @@ end
 
 Base.:(==)(a::ParametricSymbol{N}, b::ParametricSymbol{N}) where {N} =
     a.char == b.char && a.params == b.params
+# Different N type parameters → different arity → never equal
 Base.:(==)(::ParametricSymbol, ::ParametricSymbol) = false
 
 Base.hash(s::ParametricSymbol, h::UInt) =
@@ -117,7 +118,7 @@ Check whether two symbols match for rule application.
 Plain symbols match by character. Parametric symbols match by character and arity
 (parameter values are ignored for matching — they are checked by conditions).
 """
-matches(a::Symbol, b::Symbol) = a.char == b.char
+matches(a::LSymbol, b::LSymbol) = a.char == b.char
 matches(a::ParametricSymbol{N}, b::ParametricSymbol{N}) where {N} = a.char == b.char
 matches(::AbstractSymbol, ::AbstractSymbol) = false
 
@@ -131,20 +132,24 @@ matches(::AbstractSymbol, ::AbstractSymbol) = false
 An ordered sequence of L-system symbols representing one generation
 of a derivation. Supports indexing, iteration, and length.
 
+LStrings are construction-only: build a new LString for each derivation
+step rather than mutating an existing one. Use `copy` when you need an
+independent instance sharing no backing storage.
+
 # Examples
 ```julia
-ls = LString([Symbol('F'), Symbol('+'), Symbol('F')])
+ls = LString([LSymbol('F'), LSymbol('+'), LSymbol('F')])
 length(ls)  # 3
-ls[2]       # Symbol('+')
+ls[2]       # LSymbol('+')
 ```
 """
 struct LString
     symbols::Vector{AbstractSymbol}
 end
 
-# Construct from a plain string (each char → Symbol)
+# Construct from a plain string (each char → LSymbol)
 function LString(s::AbstractString)
-    LString([Symbol(c) for c in s])
+    LString([LSymbol(c) for c in s])
 end
 
 Base.length(ls::LString) = length(ls.symbols)
@@ -153,11 +158,12 @@ Base.getindex(ls::LString, r::AbstractRange) = LString(ls.symbols[r])
 Base.iterate(ls::LString) = iterate(ls.symbols)
 Base.iterate(ls::LString, state) = iterate(ls.symbols, state)
 Base.eltype(::Type{LString}) = AbstractSymbol
+Base.IteratorSize(::Type{LString}) = Base.HasLength()
+Base.IteratorEltype(::Type{LString}) = Base.HasEltype()
 Base.firstindex(ls::LString) = 1
 Base.lastindex(ls::LString) = length(ls.symbols)
 Base.isempty(ls::LString) = isempty(ls.symbols)
-Base.push!(ls::LString, s::AbstractSymbol) = (push!(ls.symbols, s); ls)
-Base.append!(ls::LString, other::LString) = (append!(ls.symbols, other.symbols); ls)
+Base.copy(ls::LString) = LString(copy(ls.symbols))
 
 function Base.show(io::IO, ls::LString)
     for s in ls.symbols
@@ -167,7 +173,7 @@ end
 
 function Base.:(==)(a::LString, b::LString)
     length(a) == length(b) || return false
-    all(a.symbols .== b.symbols)
+    all(x == y for (x, y) in zip(a.symbols, b.symbols))
 end
 
 Base.hash(ls::LString, h::UInt) = hash(ls.symbols, hash(:LString, h))

--- a/test/test_symbols.jl
+++ b/test/test_symbols.jl
@@ -1,16 +1,16 @@
 @testset "Symbols" begin
-    @testset "Plain Symbol creation" begin
-        f = Physis.Symbol('F')
+    @testset "Plain LSymbol creation" begin
+        f = LSymbol('F')
         @test name(f) == 'F'
 
-        plus = Physis.Symbol('+')
+        plus = LSymbol('+')
         @test name(plus) == '+'
     end
 
-    @testset "Plain Symbol equality and hashing" begin
-        a = Physis.Symbol('A')
-        a2 = Physis.Symbol('A')
-        b = Physis.Symbol('B')
+    @testset "Plain LSymbol equality and hashing" begin
+        a = LSymbol('A')
+        a2 = LSymbol('A')
+        b = LSymbol('B')
 
         @test a == a2
         @test a != b
@@ -18,8 +18,8 @@
         @test hash(a) != hash(b)
     end
 
-    @testset "Plain Symbol show" begin
-        f = Physis.Symbol('F')
+    @testset "Plain LSymbol show" begin
+        f = LSymbol('F')
         @test sprint(show, f) == "F"
     end
 
@@ -74,9 +74,9 @@
     end
 
     @testset "matches()" begin
-        f1 = Physis.Symbol('F')
-        f2 = Physis.Symbol('F')
-        g = Physis.Symbol('G')
+        f1 = LSymbol('F')
+        f2 = LSymbol('F')
+        g = LSymbol('G')
 
         @test matches(f1, f2)
         @test !matches(f1, g)
@@ -91,7 +91,7 @@
         @test !matches(pa1, pa3)
 
         # Different types → no match
-        plain_a = Physis.Symbol('A')
+        plain_a = LSymbol('A')
         @test !matches(plain_a, pa1)
         @test !matches(pa1, plain_a)
     end
@@ -99,8 +99,8 @@ end
 
 @testset "LString" begin
     @testset "Construction from symbols" begin
-        f = Physis.Symbol('F')
-        plus = Physis.Symbol('+')
+        f = LSymbol('F')
+        plus = LSymbol('+')
         ls = LString([f, plus, f])
 
         @test length(ls) == 3
@@ -112,10 +112,10 @@ end
     @testset "Construction from string" begin
         ls = LString("F+F-F")
         @test length(ls) == 5
-        @test ls[1] == Physis.Symbol('F')
-        @test ls[3] == Physis.Symbol('F')
-        @test ls[2] == Physis.Symbol('+')
-        @test ls[4] == Physis.Symbol('-')
+        @test ls[1] == LSymbol('F')
+        @test ls[3] == LSymbol('F')
+        @test ls[2] == LSymbol('+')
+        @test ls[4] == LSymbol('-')
     end
 
     @testset "Iteration" begin
@@ -130,27 +130,32 @@ end
         @test length(ls) == 0
     end
 
-    @testset "Push and append" begin
-        ls = LString("F")
-        push!(ls, Physis.Symbol('+'))
-        @test length(ls) == 2
-        @test ls[2] == Physis.Symbol('+')
+    @testset "Iterator traits" begin
+        @test Base.IteratorSize(LString) == Base.HasLength()
+        @test Base.IteratorEltype(LString) == Base.HasEltype()
+        @test eltype(LString) == AbstractSymbol
+    end
 
-        ls2 = LString("-F")
-        append!(ls, ls2)
-        @test length(ls) == 4
+    @testset "Copy independence" begin
+        ls1 = LString("FG")
+        ls2 = copy(ls1)
+        @test ls1 == ls2
+        # Mutating the internal vector of one must not affect the other
+        push!(ls2.symbols, LSymbol('+'))
+        @test length(ls1) == 2
+        @test length(ls2) == 3
     end
 
     @testset "Mixed parametric and plain symbols" begin
         syms = AbstractSymbol[
-            Physis.Symbol('F'),
+            LSymbol('F'),
             ParametricSymbol('A', (10.0,)),
-            Physis.Symbol('+'),
+            LSymbol('+'),
             ParametricSymbol('B', (1.0, 2.0)),
         ]
         ls = LString(syms)
         @test length(ls) == 4
-        @test ls[1] isa Physis.Symbol
+        @test ls[1] isa LSymbol
         @test ls[2] isa ParametricSymbol
         @test arity(ls[2]) == 1
         @test ls[4] isa ParametricSymbol
@@ -172,7 +177,7 @@ end
 
         # With parametric symbols
         syms = AbstractSymbol[
-            Physis.Symbol('F'),
+            LSymbol('F'),
             ParametricSymbol('A', (10.0,)),
         ]
         ls2 = LString(syms)
@@ -183,7 +188,7 @@ end
         ls = LString("ABCDE")
         sub = ls[2:4]
         @test length(sub) == 3
-        @test sub[1] == Physis.Symbol('B')
-        @test sub[3] == Physis.Symbol('D')
+        @test sub[1] == LSymbol('B')
+        @test sub[3] == LSymbol('D')
     end
 end


### PR DESCRIPTION
## Summary

- Rename `Symbol` → `LSymbol` to avoid shadowing `Base.Symbol` (was forcing `Physis.Symbol` everywhere)
- Remove `push!`/`append!` from `LString` — derivation strings should be construction-only to prevent aliasing bugs between generations
- Add `Base.copy` for `LString` (wraps mutable `Vector`, needs explicit copy for safe independent instances)
- Fix `LString` equality to use generator-based `all()` instead of broadcasting (allocation-free)
- Add `IteratorSize`/`IteratorEltype` trait declarations for `LString`
- Comment on `ParametricSymbol` catch-all `==` explaining different-arity semantics

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 61/61 pass (was 58, +3 for new iterator traits and copy tests)

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)