### PR TITLE
Phase 2: 2D Turtle Interpreter

### DIFF
--- a/src/Physis.jl
+++ b/src/Physis.jl
@@ -7,10 +7,14 @@ include("core/symbols.jl")
 include("core/rules.jl")
 include("core/rewriter.jl")
 
+# ── Turtle interpreters ─────────────────────────────────────────
+include("turtle/turtle2d.jl")
+
 # Re-export public API
 export AbstractSymbol, LSymbol, ParametricSymbol, LString
 export name, arity, params, matches
 export AbstractRule, Rule, ParametricRule, StochasticRule, RuleSet
 export rewrite_step, derive, apply_rule
+export LineSegment2D, interpret2d
 
 end # module Physis

--- a/src/turtle/turtle2d.jl
+++ b/src/turtle/turtle2d.jl
@@ -1,0 +1,117 @@
+"""
+    turtle2d.jl — 2D turtle graphics interpreter for L-strings
+
+Converts an LString into a list of line segments by interpreting symbols
+as turtle commands: forward, turn, push/pop branch state.
+
+Reference: ABOP §1.5 (Graphical interpretation of strings)
+"""
+
+using StaticArrays
+
+# ──────────────────────────────────────────────────────────────────
+# Types
+# ──────────────────────────────────────────────────────────────────
+
+"""
+    LineSegment2D(start, stop)
+
+A 2D line segment from `start` to `stop`, both `SVector{2,Float64}`.
+"""
+struct LineSegment2D
+    start::SVector{2, Float64}
+    stop::SVector{2, Float64}
+end
+
+Base.:(==)(a::LineSegment2D, b::LineSegment2D) = a.start == b.start && a.stop == b.stop
+
+"""
+    TurtleState2D
+
+Internal mutable state for the 2D turtle interpreter.
+Position and heading (in radians, counter-clockwise from +x axis).
+"""
+mutable struct TurtleState2D
+    pos::SVector{2, Float64}
+    heading::Float64   # radians, CCW from +x
+    step::Float64
+end
+
+function TurtleState2D(; step::Float64=1.0)
+    TurtleState2D(SVector(0.0, 0.0), π / 2, step)  # default heading up
+end
+
+Base.copy(t::TurtleState2D) = TurtleState2D(t.pos, t.heading, t.step)
+
+# ──────────────────────────────────────────────────────────────────
+# Interpreter
+# ──────────────────────────────────────────────────────────────────
+
+"""
+    interpret2d(ls::LString; angle=25.0, step=1.0) -> Vector{LineSegment2D}
+
+Interpret an L-string as 2D turtle graphics commands, returning line segments.
+
+# Symbol commands
+- `F` / `F(d)` — move forward by `step` (or `d`), drawing a line
+- `f` / `f(d)` — move forward without drawing
+- `+` / `+(a)` — turn left by `angle` degrees (or `a` degrees)
+- `-` / `-(a)` — turn right by `angle` degrees (or `a` degrees)
+- `[` — push turtle state onto branch stack
+- `]` — pop turtle state from branch stack
+- All other symbols — ignored
+
+# Arguments
+- `angle`: default turn angle in degrees (default 25.0)
+- `step`: default forward step size (default 1.0)
+
+Reference: ABOP §1.5
+"""
+function interpret2d(ls::LString; angle::Real=25.0, step::Real=1.0)
+    turtle = TurtleState2D(; step=Float64(step))
+    angle_rad = deg2rad(Float64(angle))
+    stack = TurtleState2D[]
+    segments = LineSegment2D[]
+
+    for sym in ls
+        c = name(sym)
+        if c == 'F'
+            d = _get_step(sym, turtle.step)
+            new_pos = turtle.pos + SVector(d * cos(turtle.heading), d * sin(turtle.heading))
+            push!(segments, LineSegment2D(turtle.pos, new_pos))
+            turtle.pos = new_pos
+        elseif c == 'f'
+            d = _get_step(sym, turtle.step)
+            turtle.pos = turtle.pos + SVector(d * cos(turtle.heading), d * sin(turtle.heading))
+        elseif c == '+'
+            a = _get_angle(sym, angle_rad)
+            turtle.heading += a
+        elseif c == '-'
+            a = _get_angle(sym, angle_rad)
+            turtle.heading -= a
+        elseif c == '['
+            push!(stack, copy(turtle))
+        elseif c == ']'
+            isempty(stack) && throw(ArgumentError("unmatched ']': no state to pop from branch stack"))
+            restored = pop!(stack)
+            turtle.pos = restored.pos
+            turtle.heading = restored.heading
+            turtle.step = restored.step
+        end
+        # All other symbols: no-op
+    end
+
+    segments
+end
+
+# ──────────────────────────────────────────────────────────────────
+# Internal helpers
+# ──────────────────────────────────────────────────────────────────
+
+"""Extract step distance from a parametric symbol, or use default."""
+_get_step(::LSymbol, default::Float64) = default
+_get_step(sym::ParametricSymbol, default::Float64) = sym.params[1]
+
+"""Extract angle (converting degrees → radians) from a parametric symbol, or use default (already radians)."""
+_get_angle(::LSymbol, default_rad::Float64) = default_rad
+_get_angle(sym::ParametricSymbol, ::Float64) = deg2rad(sym.params[1])

--- a/src/turtle/turtle2d.jl
+++ b/src/turtle/turtle2d.jl
@@ -24,6 +24,13 @@ struct LineSegment2D
 end
 
 Base.:(==)(a::LineSegment2D, b::LineSegment2D) = a.start == b.start && a.stop == b.stop
+Base.hash(s::LineSegment2D, h::UInt) = hash(s.stop, hash(s.start, hash(:LineSegment2D, h)))
+Base.isapprox(a::LineSegment2D, b::LineSegment2D; kwargs...) =
+    isapprox(a.start, b.start; kwargs...) && isapprox(a.stop, b.stop; kwargs...)
+
+function Base.show(io::IO, s::LineSegment2D)
+    print(io, "(", s.start[1], ",", s.start[2], ")→(", s.stop[1], ",", s.stop[2], ")")
+end
 
 """
     TurtleState2D
@@ -72,23 +79,32 @@ function interpret2d(ls::LString; angle::Real=25.0, step::Real=1.0)
     angle_rad = deg2rad(Float64(angle))
     stack = TurtleState2D[]
     segments = LineSegment2D[]
+    # Pre-count F symbols to avoid repeated reallocation
+    sizehint!(segments, count(s -> name(s) == 'F', ls))
+    # Cache direction vector; recompute only when heading changes
+    dir = SVector(cos(turtle.heading), sin(turtle.heading))
+    heading_dirty = false
 
     for sym in ls
         c = name(sym)
         if c == 'F'
+            heading_dirty && (dir = SVector(cos(turtle.heading), sin(turtle.heading)); heading_dirty = false)
             d = _get_step(sym, turtle.step)
-            new_pos = turtle.pos + SVector(d * cos(turtle.heading), d * sin(turtle.heading))
+            new_pos = turtle.pos + d * dir
             push!(segments, LineSegment2D(turtle.pos, new_pos))
             turtle.pos = new_pos
         elseif c == 'f'
+            heading_dirty && (dir = SVector(cos(turtle.heading), sin(turtle.heading)); heading_dirty = false)
             d = _get_step(sym, turtle.step)
-            turtle.pos = turtle.pos + SVector(d * cos(turtle.heading), d * sin(turtle.heading))
+            turtle.pos = turtle.pos + d * dir
         elseif c == '+'
             a = _get_angle(sym, angle_rad)
-            turtle.heading += a
+            turtle.heading = mod2pi(turtle.heading + a)
+            heading_dirty = true
         elseif c == '-'
             a = _get_angle(sym, angle_rad)
-            turtle.heading -= a
+            turtle.heading = mod2pi(turtle.heading - a)
+            heading_dirty = true
         elseif c == '['
             push!(stack, copy(turtle))
         elseif c == ']'
@@ -97,6 +113,7 @@ function interpret2d(ls::LString; angle::Real=25.0, step::Real=1.0)
             turtle.pos = restored.pos
             turtle.heading = restored.heading
             turtle.step = restored.step
+            heading_dirty = true
         end
         # All other symbols: no-op
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Physis
 include("test_symbols.jl")
 include("test_rules.jl")
 include("test_rewriter.jl")
+include("test_turtle2d.jl")

--- a/test/test_turtle2d.jl
+++ b/test/test_turtle2d.jl
@@ -10,6 +10,27 @@ using StaticArrays
             @test seg.stop == p2
             @test seg == LineSegment2D(p1, p2)
         end
+
+        @testset "hash — usable in Set/Dict" begin
+            s1 = LineSegment2D(SVector(0.0, 0.0), SVector(1.0, 0.0))
+            s2 = LineSegment2D(SVector(0.0, 0.0), SVector(1.0, 0.0))
+            s3 = LineSegment2D(SVector(0.0, 0.0), SVector(0.0, 1.0))
+            @test hash(s1) == hash(s2)
+            @test length(Set([s1, s2, s3])) == 2
+        end
+
+        @testset "isapprox" begin
+            s1 = LineSegment2D(SVector(0.0, 0.0), SVector(1.0, 0.0))
+            s2 = LineSegment2D(SVector(0.0, 0.0), SVector(1.0 + 1e-15, 0.0))
+            s3 = LineSegment2D(SVector(0.0, 0.0), SVector(2.0, 0.0))
+            @test s1 ≈ s2
+            @test !(s1 ≈ s3)
+        end
+
+        @testset "show" begin
+            seg = LineSegment2D(SVector(0.0, 1.0), SVector(2.0, 3.0))
+            @test contains(sprint(show, seg), "→")
+        end
     end
 
     @testset "interpret2d basics" begin
@@ -137,12 +158,29 @@ using StaticArrays
             @test segs[1].start ≈ SVector(0.0, 5.0)
             @test segs[1].stop ≈ SVector(0.0, 6.0)
         end
+
+        @testset "Extra params ignored — only first param used" begin
+            # F(3.0, 99.0) should use 3.0 as step, ignore 99.0
+            ls = LString([ParametricSymbol('F', (3.0, 99.0))])
+            segs = interpret2d(ls; angle=90.0, step=1.0)
+            @test length(segs) == 1
+            @test segs[1].stop ≈ SVector(0.0, 3.0)
+        end
     end
 
     @testset "Unknown symbols are no-ops" begin
         segs = interpret2d(LString("XFYF"); angle=90.0, step=1.0)
         @test length(segs) == 2
         @test segs[1].start ≈ SVector(0.0, 0.0)
+    end
+
+    @testset "Heading normalization — many turns don't drift" begin
+        # 360° of left turns then F should end up same as just F
+        segs_direct = interpret2d(LString("F"); angle=90.0, step=1.0)
+        segs_rotated = interpret2d(LString("++++F"); angle=90.0, step=1.0)
+        @test length(segs_rotated) == 1
+        @test segs_rotated[1].start ≈ SVector(0.0, 0.0)
+        @test segs_rotated[1].stop ≈ segs_direct[1].stop atol=1e-12
     end
 
     @testset "Zero step and zero angle" begin

--- a/test/test_turtle2d.jl
+++ b/test/test_turtle2d.jl
@@ -1,0 +1,189 @@
+using StaticArrays
+
+@testset "Turtle2D" begin
+    @testset "LineSegment2D" begin
+        @testset "Construction and equality" begin
+            p1 = SVector(0.0, 0.0)
+            p2 = SVector(1.0, 0.0)
+            seg = LineSegment2D(p1, p2)
+            @test seg.start == p1
+            @test seg.stop == p2
+            @test seg == LineSegment2D(p1, p2)
+        end
+    end
+
+    @testset "interpret2d basics" begin
+        @testset "Empty LString → no segments" begin
+            result = interpret2d(LString(AbstractSymbol[]))
+            @test isempty(result)
+        end
+
+        @testset "No F symbols → no segments" begin
+            result = interpret2d(LString("+-+-"))
+            @test isempty(result)
+        end
+
+        @testset "Single F draws one segment upward" begin
+            segs = interpret2d(LString("F"); angle=90.0, step=1.0)
+            @test length(segs) == 1
+            @test segs[1].start ≈ SVector(0.0, 0.0)
+            @test segs[1].stop ≈ SVector(0.0, 1.0)
+        end
+
+        @testset "Two F's draw two connected segments" begin
+            segs = interpret2d(LString("FF"); angle=90.0, step=1.0)
+            @test length(segs) == 2
+            @test segs[1].start ≈ SVector(0.0, 0.0)
+            @test segs[1].stop ≈ SVector(0.0, 1.0)
+            @test segs[2].start ≈ SVector(0.0, 1.0)
+            @test segs[2].stop ≈ SVector(0.0, 2.0)
+        end
+    end
+
+    @testset "Turning" begin
+        @testset "F+F with 90° angle turns left" begin
+            # Start heading up (90°), + turns left → heading 180° (left)
+            segs = interpret2d(LString("F+F"); angle=90.0, step=1.0)
+            @test length(segs) == 2
+            @test segs[2].start ≈ SVector(0.0, 1.0)
+            @test segs[2].stop ≈ SVector(-1.0, 1.0) atol=1e-12
+        end
+
+        @testset "F-F with 90° angle turns right" begin
+            # Start heading up (90°), - turns right → heading 0° (right)
+            segs = interpret2d(LString("F-F"); angle=90.0, step=1.0)
+            @test length(segs) == 2
+            @test segs[2].start ≈ SVector(0.0, 1.0)
+            @test segs[2].stop ≈ SVector(1.0, 1.0) atol=1e-12
+        end
+
+        @testset "Custom angle" begin
+            # 60° turn: heading starts at 90°, + turns to 150°
+            segs = interpret2d(LString("F+F"); angle=60.0, step=1.0)
+            @test length(segs) == 2
+            expected_x = cos(deg2rad(150.0))
+            expected_y = 1.0 + sin(deg2rad(150.0))
+            @test segs[2].stop ≈ SVector(expected_x, expected_y) atol=1e-12
+        end
+    end
+
+    @testset "Move without drawing (f)" begin
+        @testset "f moves position but produces no segment" begin
+            segs = interpret2d(LString("fF"); angle=90.0, step=1.0)
+            @test length(segs) == 1
+            @test segs[1].start ≈ SVector(0.0, 1.0)
+            @test segs[1].stop ≈ SVector(0.0, 2.0)
+        end
+    end
+
+    @testset "Branching" begin
+        @testset "Push/pop preserves state" begin
+            # F[+F]F — branch left then continue straight
+            segs = interpret2d(LString("F[+F]F"); angle=90.0, step=1.0)
+            @test length(segs) == 3
+            # First F: (0,0)→(0,1)
+            @test segs[1].start ≈ SVector(0.0, 0.0)
+            @test segs[1].stop ≈ SVector(0.0, 1.0)
+            # Branch F: from (0,1) heading left → (-1,1)
+            @test segs[2].start ≈ SVector(0.0, 1.0)
+            @test segs[2].stop ≈ SVector(-1.0, 1.0) atol=1e-12
+            # After pop, continue from (0,1) heading up → (0,2)
+            @test segs[3].start ≈ SVector(0.0, 1.0)
+            @test segs[3].stop ≈ SVector(0.0, 2.0)
+        end
+
+        @testset "Nested branches" begin
+            # F[+F[-F]]F
+            segs = interpret2d(LString("F[+F[-F]]F"); angle=90.0, step=1.0)
+            @test length(segs) == 4
+            # After all pops, last F continues from (0,1) heading up
+            @test segs[4].start ≈ SVector(0.0, 1.0)
+            @test segs[4].stop ≈ SVector(0.0, 2.0)
+        end
+
+        @testset "Mismatched ] throws ArgumentError" begin
+            @test_throws ArgumentError interpret2d(LString("]F"))
+        end
+
+        @testset "Unclosed [ is allowed" begin
+            # No error — stack simply not fully popped
+            segs = interpret2d(LString("[F"))
+            @test length(segs) == 1
+        end
+    end
+
+    @testset "Parametric symbols" begin
+        @testset "F(d) uses custom step" begin
+            ls = LString([ParametricSymbol('F', (3.0,))])
+            segs = interpret2d(ls; angle=90.0, step=1.0)
+            @test length(segs) == 1
+            @test segs[1].start ≈ SVector(0.0, 0.0)
+            @test segs[1].stop ≈ SVector(0.0, 3.0)
+        end
+
+        @testset "+(a) and -(a) use custom angle" begin
+            # F +(45) F — turn left 45° from heading 90° → heading 135°
+            ls = LString([LSymbol('F'), ParametricSymbol('+', (45.0,)), LSymbol('F')])
+            segs = interpret2d(ls; angle=90.0, step=1.0)
+            @test length(segs) == 2
+            expected = SVector(cos(deg2rad(135.0)), 1.0 + sin(deg2rad(135.0)))
+            @test segs[2].stop ≈ expected atol=1e-12
+        end
+
+        @testset "f(d) moves without drawing by custom distance" begin
+            ls = LString([ParametricSymbol('f', (5.0,)), LSymbol('F')])
+            segs = interpret2d(ls; angle=90.0, step=1.0)
+            @test length(segs) == 1
+            @test segs[1].start ≈ SVector(0.0, 5.0)
+            @test segs[1].stop ≈ SVector(0.0, 6.0)
+        end
+    end
+
+    @testset "Unknown symbols are no-ops" begin
+        segs = interpret2d(LString("XFYF"); angle=90.0, step=1.0)
+        @test length(segs) == 2
+        @test segs[1].start ≈ SVector(0.0, 0.0)
+    end
+
+    @testset "Zero step and zero angle" begin
+        segs = interpret2d(LString("F"); angle=0.0, step=0.0)
+        @test length(segs) == 1
+        @test segs[1].start ≈ segs[1].stop
+    end
+
+    @testset "Integration with derive" begin
+        @testset "Koch curve segment count" begin
+            # Koch curve: F → F+F-F-F+F, angle 90°
+            # RHS has 5 F's, so segment count = 5^n
+            # Gen 0: 1, Gen 1: 5, Gen 2: 25
+            r = Rule(LSymbol('F'), LString("F+F-F-F+F"))
+            rs = RuleSet([r])
+            axiom = LString("F")
+
+            gen0 = axiom
+            @test length(interpret2d(gen0; angle=90.0)) == 1
+
+            gen1 = derive(axiom, rs, 1)
+            @test length(interpret2d(gen1; angle=90.0)) == 5
+
+            gen2 = derive(axiom, rs, 2)
+            @test length(interpret2d(gen2; angle=90.0)) == 25
+        end
+
+        @testset "Koch snowflake (ABOP §1.5)" begin
+            # Axiom: F--F--F (equilateral triangle)
+            # Rule: F → F+F--F+F, angle 60°
+            # Gen 0: 3 segments, Gen 1: 12 segments
+            r = Rule(LSymbol('F'), LString("F+F--F+F"))
+            rs = RuleSet([r])
+            axiom = LString("F--F--F")
+
+            gen0_segs = interpret2d(axiom; angle=60.0)
+            @test length(gen0_segs) == 3
+
+            gen1 = derive(axiom, rs, 1)
+            gen1_segs = interpret2d(gen1; angle=60.0)
+            @test length(gen1_segs) == 12  # 3 * 4
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- Implement `interpret2d()` that converts L-strings into `Vector{LineSegment2D}` via turtle graphics
- Support standard turtle commands: `F`/`f` (draw/move), `+`/`-` (turn), `[`/`]` (branch push/pop)
- Support parametric overrides: `F(d)` for custom step, `+(a)`/`-(a)` for custom angle
- End-to-end integration with `derive()` — Koch curve and Koch snowflake produce correct segment counts

Closes #7

## Files

| File | Purpose |
|------|---------|
| `src/turtle/turtle2d.jl` | `TurtleState2D`, `LineSegment2D`, `interpret2d` |
| `test/test_turtle2d.jl` | 53 tests covering all acceptance criteria |
| `src/Physis.jl` | Include + export new public API |
| `test/runtests.jl` | Include test file |

## Test plan

- [x] 173 tests pass (120 existing + 53 new)
- [x] Empty/no-F L-strings return empty segments
- [x] Single/multi F draws correct geometry
- [x] Turning left (+) and right (-) with default and custom angles
- [x] Move without drawing (f)
- [x] Push/pop branching ([/]) including nested
- [x] Mismatched `]` throws ArgumentError
- [x] Parametric F(d), +(a), -(a), f(d) override defaults
- [x] Unknown symbols are no-ops
- [x] Zero step/angle edge case
- [x] Koch curve: segment count = 5^n
- [x] Koch snowflake (ABOP §1.5): 3→12 segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)