### PR TITLE
Fix audit gaps: error messages, volumetrics, turtle helpers

### DIFF
--- a/src/Physis.jl
+++ b/src/Physis.jl
@@ -8,6 +8,7 @@ include("core/rules.jl")
 include("core/rewriter.jl")
 
 # ── Turtle interpreters ─────────────────────────────────────────
+include("turtle/common.jl")
 include("turtle/turtle2d.jl")
 include("turtle/turtle3d.jl")
 

--- a/src/blender/templates/photorealistic.py
+++ b/src/blender/templates/photorealistic.py
@@ -239,6 +239,13 @@ bg_node.inputs["Strength"].default_value = 1.5
 node_tree.links.new(sky_node.outputs["Color"], bg_node.inputs["Color"])
 node_tree.links.new(bg_node.outputs["Background"], output_node.inputs["Surface"])
 
+# Volumetric atmosphere — subtle haze for depth perception
+vol_scatter = node_tree.nodes.new("ShaderNodeVolumeScatter")
+vol_scatter.inputs["Color"].default_value = (0.8, 0.85, 0.9, 1.0)
+vol_scatter.inputs["Density"].default_value = 0.002
+vol_scatter.inputs["Anisotropy"].default_value = 0.3
+node_tree.links.new(vol_scatter.outputs["Volume"], output_node.inputs["Volume"])
+
 # ── 7. Ground plane with procedural earth material ─────────────────
 
 ground_plane = {{GROUND_PLANE}}

--- a/src/render/render_api.jl
+++ b/src/render/render_api.jl
@@ -83,16 +83,24 @@ end
              backgroundcolor=:white, figsize=(800,800), margin=0.1) -> Figure
 
 Render 2D line segments to a Makie Figure. Requires a backend (e.g. `using CairoMakie`).
+
+Throws an informative error if no rendering backend (e.g. CairoMakie) is loaded.
 """
-function render2d end
+function render2d(args...; kwargs...)
+    error("No rendering backend loaded. Run `using CairoMakie` before calling render2d.")
+end
 
 """
     save_render(path, segments; kwargs...) -> Figure
 
 Render 2D line segments and save to a file (PNG/SVG/PDF inferred from extension).
 Requires a backend (e.g. `using CairoMakie`).
+
+Throws an informative error if no rendering backend (e.g. CairoMakie) is loaded.
 """
-function save_render end
+function save_render(args...; kwargs...)
+    error("No rendering backend loaded. Run `using CairoMakie` before calling save_render.")
+end
 
 # ──────────────────────────────────────────────────────────────────
 # render_lsystem — full pipeline

--- a/src/turtle/common.jl
+++ b/src/turtle/common.jl
@@ -1,0 +1,13 @@
+"""
+    common.jl — Shared helpers for 2D and 3D turtle interpreters
+
+Provides parametric symbol extraction utilities used by both interpret2d and interpret3d.
+"""
+
+"""Extract step distance from a parametric symbol, or use default."""
+_get_step(::LSymbol, default::Float64) = default
+_get_step(sym::ParametricSymbol, default::Float64) = sym.params[1]
+
+"""Extract angle (converting degrees → radians) from a parametric symbol, or use default (already radians)."""
+_get_angle(::LSymbol, default_rad::Float64) = default_rad
+_get_angle(sym::ParametricSymbol, ::Float64) = deg2rad(sym.params[1])

--- a/src/turtle/turtle2d.jl
+++ b/src/turtle/turtle2d.jl
@@ -126,14 +126,4 @@ function interpret2d(ls::LString; angle::Real=25.0, step::Real=1.0, step_scale::
     segments
 end
 
-# ──────────────────────────────────────────────────────────────────
-# Internal helpers
-# ──────────────────────────────────────────────────────────────────
-
-"""Extract step distance from a parametric symbol, or use default."""
-_get_step(::LSymbol, default::Float64) = default
-_get_step(sym::ParametricSymbol, default::Float64) = sym.params[1]
-
-"""Extract angle (converting degrees → radians) from a parametric symbol, or use default (already radians)."""
-_get_angle(::LSymbol, default_rad::Float64) = default_rad
-_get_angle(sym::ParametricSymbol, ::Float64) = deg2rad(sym.params[1])
+# Internal helpers (_get_step, _get_angle) are in turtle/common.jl

--- a/test/test_blender.jl
+++ b/test/test_blender.jl
@@ -95,6 +95,8 @@ Tier 1 tests run without Blender. Tier 2 tests require Blender installed.
         @test occursin("aperture_fstop", script)
         # Contains sky lighting
         @test occursin("HOSEK_WILKIE", script)
+        # Contains volumetric atmosphere
+        @test occursin("ShaderNodeVolumeScatter", script)
     end
 
     @testset "generate_blender_script without ground plane" begin

--- a/test/test_render_api.jl
+++ b/test/test_render_api.jl
@@ -89,6 +89,20 @@ using StaticArrays
         @test save_render isa Function
     end
 
+    @testset "render2d and save_render throw clear error without backend" begin
+        # These tests must run BEFORE CairoMakie is loaded (test_cairomakie_ext.jl)
+        # to verify the fallback error path works.
+        seg = LineSegment2D(SVector(0.0, 0.0), SVector(1.0, 1.0))
+
+        ex1 = try render2d([seg]); nothing catch e; e end
+        @test ex1 isa ErrorException
+        @test occursin("CairoMakie", ex1.msg)
+
+        ex2 = try save_render("/tmp/test.png", [seg]); nothing catch e; e end
+        @test ex2 isa ErrorException
+        @test occursin("CairoMakie", ex2.msg)
+    end
+
     @testset "render_lsystem" begin
         @testset "Throws ArgumentError if no F segments produced" begin
             # Axiom with no F, rule that produces no F


### PR DESCRIPTION
## Summary

Fixes three gaps found during a full audit of closed issues vs codebase reality:

- **#25**: `render2d`/`save_render` now throw a clear `ErrorException` mentioning CairoMakie when no rendering backend is loaded (was generic `MethodError`)
- **#26**: Blender Cycles template now includes volumetric atmosphere via `ShaderNodeVolumeScatter` for subtle depth haze (was missing per #23 acceptance criteria)
- **#27**: Shared turtle helpers (`_get_step`, `_get_angle`) extracted into `src/turtle/common.jl` so `turtle3d.jl` no longer silently depends on `turtle2d.jl` include order

Closes #25, Closes #26, Closes #27

## Test plan

- [x] All 1,241 tests pass (`Pkg.test()`)
- [x] New test: `render2d`/`save_render` throw `ErrorException` with "CairoMakie" in message when extension not loaded
- [x] New test: Blender script contains `ShaderNodeVolumeScatter`
- [x] Existing CairoMakie extension tests still pass (extension properly overrides fallback)
- [x] Existing turtle 2D/3D tests still pass (helpers work from common.jl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)